### PR TITLE
add test for gzip response

### DIFF
--- a/quest_test.go
+++ b/quest_test.go
@@ -246,6 +246,14 @@ func TestSetHeader(t *testing.T) {
 	})
 }
 
+func TestGzipResponse(t *testing.T) {
+	Convey("auto decompression gzip by net/http", t, func() {
+		q, _ := Request("GET", "http://httpbin.org/gzip")
+		s, _ := q.String()
+		So(s, ShouldContainSubstring, `"gzipped": true`)
+	})
+}
+
 func TestBytesNotHandler(t *testing.T) {
 	queryParams := url.Values{}
 	queryParams.Set("foo", "bar")


### PR DESCRIPTION
@fundon forgive me 
http://golang.org/pkg/net/http/#Transport golang has handled the decompression
so, just add a test to point this

close #9 
